### PR TITLE
add hosts to /etc/hosts

### DIFF
--- a/add-hosts.yml
+++ b/add-hosts.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Gather facts change /etc/hasts
+  hosts: all
+  gather_facts: true
+  become: true
+  roles:
+    - hosts-file

--- a/roles/hosts-file/tasks/main.yaml
+++ b/roles/hosts-file/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+# tasks file for hosts-file
+- name: Update /etc/hosts file
+  ansible.builtin.blockinfile:
+    dest: /etc/hosts
+    content: "{{ lookup('template', 'templates/etc/hosts.j2') }}"
+    state: present

--- a/roles/hosts-file/templates/etc/hosts.j2
+++ b/roles/hosts-file/templates/etc/hosts.j2
@@ -1,0 +1,3 @@
+{% for host in groups['all'] %}
+ {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+{% endfor %}


### PR DESCRIPTION
a playbook to run a role with on template. Only for testing.
Adds all hosts from ansibles inventory to `/etc/hosts` => no waiting till DNS gives the new/right information